### PR TITLE
feature: Search on parentid and output in json format, optionally with filename

### DIFF
--- a/src/entities/media_details.rs
+++ b/src/entities/media_details.rs
@@ -1071,4 +1071,8 @@ impl MediaRoot {
         }
         println!("{table}");
     }
+
+    pub fn json_print(media: MediaRoot) {
+        println!("{}", serde_json::to_string_pretty(&media).unwrap());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -824,18 +824,6 @@ fn main() -> Result<(), confy::ConfyError> {
             }
         },
         Commands::SearchMedia { term, mediatype, parentid, include_filepath, json } => {
-            /*
-            let mut query = 
-                vec![
-                    ("SortBy", "SortName,ProductionYear"),
-                    ("Recursive", "true"),
-                    ("searchTerm", &term)
-                ];
-            if mediatype != "all" {
-                query.push(("IncludeItemTypes", &mediatype));
-            }
-            */
-
             let search_result = execute_search(&term, mediatype, parentid, include_filepath, &cfg);
 
             if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,13 @@ struct Cli {
         term: String,
         /// Filter for media type
         #[clap(required = false, short, long, default_value="all")]
-        mediatype: String
+        mediatype: String,
+        #[clap(required = false, short, long, default_value="")]
+        parentid: String,
+        #[clap(long, required = false)]
+        json: bool,
+        #[clap(short = 'f', long, required = false)]
+        include_filepath: bool
     },
     /// Updates image of specified file by name
     UpdateImageByName {
@@ -395,7 +401,7 @@ fn main() -> Result<(), confy::ConfyError> {
 
         },
         Commands::UpdateImageByName { title, path, imagetype } => {
-            let search: MediaRoot = execute_search(&title, "all".to_string(), &cfg);
+            let search: MediaRoot = execute_search(&title, "all".to_string(), "".to_string(), false, &cfg);
             if search.total_record_count > 1 {
                 eprintln!("Too many results found.  Updating by name requires a unique search term.");
                 std::process::exit(1);
@@ -817,7 +823,8 @@ fn main() -> Result<(), confy::ConfyError> {
                 }
             }
         },
-        Commands::SearchMedia { term, mediatype } => {
+        Commands::SearchMedia { term, mediatype, parentid, include_filepath, json } => {
+            /*
             let mut query = 
                 vec![
                     ("SortBy", "SortName,ProductionYear"),
@@ -827,17 +834,25 @@ fn main() -> Result<(), confy::ConfyError> {
             if mediatype != "all" {
                 query.push(("IncludeItemTypes", &mediatype));
             }
-            MediaRoot::table_print(execute_search(&term, mediatype, &cfg));
+            */
+
+            let search_result = execute_search(&term, mediatype, parentid, include_filepath, &cfg);
+
+            if json {
+                MediaRoot::json_print(search_result);
+            } else {
+                MediaRoot::table_print(search_result);
+            }
         }
     }
-    
+
     Ok(())
 }
 
 ///
 /// Executes a search with the passed parameters.
 /// 
-fn execute_search(term: &str, mediatype: String, cfg: &AppConfig) -> MediaRoot {
+fn execute_search(term: &str, mediatype: String, parentid: String, include_filepath: bool, cfg: &AppConfig) -> MediaRoot {
     let mut query =
         vec![
             ("SortBy", "SortName,ProductionYear"),
@@ -846,6 +861,14 @@ fn execute_search(term: &str, mediatype: String, cfg: &AppConfig) -> MediaRoot {
         ];
     if mediatype != "all" {
         query.push(("IncludeItemTypes", &mediatype));
+    }
+
+    if include_filepath {
+        query.push(("fields", "Path"));
+    }
+
+    if parentid != "" {
+        query.push(("parentId", &parentid));
     }
 
     match get_search_results(ServerInfo::new("/Items", &cfg.server_url, &cfg.api_key), query) {


### PR DESCRIPTION
Hey there, first of all, thanks for the great project :-) 

I wanted to use JellyRoller in scripts, to search for contents of a boxset, and get a list of files. Thankfully it's already possible to get a list of boxsets easily with something like this;

```
jellyroller search-media --mediatype BoxSet --term Bond
```

However, to then get the media items in that box set, so the first change that this PR introduceds it searching on `--parentid`. I combined this with another flag to ask the search engine for filepaths in the results (`-f` - only used in JSON output). These changes allowed made it then easy to get the contents of a box set, like this;

```
jellyroller search-media --parentid 1234abcd -t "" -f 
```

I then wanted to combine it with a shell script, and becase parsing the table output is tedius, so I added --json support, so I could just pull out fields (like .Path) that I needed.

```
jellyroller search-media --parentid 1234abcd -t "" -f --json  jq '.Items.[].Path'
```

Which gives me a really nice list of filenames :-)

I hope that you will consider this PR for inclusion into the project. 

Note: I tried to keep the PR clean, but I didn't see a CONTRIBUTING guide, pull request template, unit tests, and this is my first patch ever in rust, so I'm not sure what idiomatic rust style looks like - I tried my best looking at other code styling. I hope that it's OK! 

