### PR TITLE
fix: invert user enable/disable commands

### DIFF
--- a/src/commands/user_commands.rs
+++ b/src/commands/user_commands.rs
@@ -108,11 +108,11 @@ pub fn command_reset_password(cfg: AppConfig, username: &str, password: String, 
 }
 
 pub fn command_disable_user(cfg: &AppConfig, username: &str, user_policy_endpoint: &str, user_id_endpoint: &str) {
-    modify_user(cfg, username, user_policy_endpoint, user_id_endpoint, &UserMods::Active, false);
+    modify_user(cfg, username, user_policy_endpoint, user_id_endpoint, &UserMods::Active, true);
 }
 
 pub fn command_enable_user(cfg: &AppConfig, username: &str, user_policy_endpoint: &str, user_id_endpoint: &str) {
-    modify_user(cfg, username, user_policy_endpoint, user_id_endpoint, &UserMods::Active, true);
+    modify_user(cfg, username, user_policy_endpoint, user_id_endpoint, &UserMods::Active, false);
 }
 
 pub fn command_grant_admin(cfg: &AppConfig, username: &str, user_policy_endpoint: &str, user_id_endpoint: &str) {


### PR DESCRIPTION
Running `jellyroller disable-user <username>` sets `Policy.IsDisabled` to false, and running `jellyroller enable-user <username>` sets `Policy.IsDisabled` to true. The commands behave exactly opposite to their names.

**Reproduce**
```
$ jellyroller disable-user tv
User tv successfully updated.
$ jellyroller list-users | jq '.[] | select(.Name == "tv") | .Policy.IsDisabled'
false # verified via jellyfin admin that the user is actually enabled now

$ jellyroller enable-user tv
User tv successfully updated.
$ jellyroller list-users | jq '.[] | select(.Name == "tv") | .Policy.IsDisabled'
true
```

**Fix**

Swapping the mod_flag