### PR TITLE
Optionally skip metadata/trickplay/subtitles when creating backup

### DIFF
--- a/src/commands/server_commands.rs
+++ b/src/commands/server_commands.rs
@@ -182,9 +182,12 @@ pub fn command_register_repository(cfg: &AppConfig, name: String, path: String) 
     );
 }
 
-pub fn command_create_backup(cfg: &AppConfig) {
+pub fn command_create_backup(cfg: &AppConfig, metadata: bool, trickplay: bool, subtitles: bool) {
     let server_info = ServerInfo::new("/Backup/Create", &cfg.server_url, &cfg.api_key);
-    let body= "{\"Metadata\": true,\"Trickplay\": true,\"Subtitles\": true,\"Database\": true}";
+    let body = format!(
+        "{{\"Metadata\": {},\"Trickplay\": {},\"Subtitles\": {},\"Database\": true}}",
+        metadata, trickplay, subtitles
+    );
     let response = simple_post(
         server_info.server_url,
         &cfg.api_key,

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,17 @@ enum Commands {
         shell: Shell,
     },
     /// Creates a new backup (metadata, trickplay, subtitles, database)
-    CreateBackup {},
+    CreateBackup {
+        /// Skip backing up metadata
+        #[clap(long, required = false)]
+        skip_metadata: bool,
+        /// Skip backing up trickplay
+        #[clap(long, required = false)]
+        skip_trickplay: bool,
+        /// Skip backing up subtitles
+        #[clap(long, required = false)]
+        skip_subtitles: bool,
+    },
     /// Creates a report of either activity or available items (movie, series, boxset)
     CreateReport {
         /// Type of report (activity, movie, series, boxset)
@@ -513,7 +523,7 @@ fn main() -> Result<(), confy::ConfyError> {
         
         // Server Commands
         Commands::ApplyBackup { filename } => command_apply_backup(&cfg, &filename),
-        Commands::CreateBackup {} => command_create_backup(&cfg),
+        Commands::CreateBackup { skip_metadata, skip_trickplay, skip_subtitles} => command_create_backup(&cfg, !skip_metadata, !skip_trickplay, !skip_subtitles),
         Commands::ExecuteTaskByName { task } => command_execute_task_by_name(&cfg, &task),
         Commands::GetBackups { output_format } => command_get_backups(&cfg, &output_format, BACKUPS),
         Commands::GetDevices { active, output_format} => command_get_devices(&cfg, active, &output_format, DEVICES),


### PR DESCRIPTION
I do regular backups and want Jellyfin to only create a zip of the database. After that, I back up the zip together with metadata, trickplay data, and subtitles using restic. This keeps the backups minimal, since data that rarely changes does not get re-compressed every time.

I previously used the Web UI for this, but I really like this project as it makes the process much easier to automate.

Jellyfin already has the ability to choose which things to backup via the API, so I think it is nice to expose those options. 

Note: this PR does not add support for skipping the database backup, as Jellyfin automatically includes it when creating a backup regardless of the value sent with `Database`.